### PR TITLE
Improved dependencies

### DIFF
--- a/src/lib/BUILD
+++ b/src/lib/BUILD
@@ -1,7 +1,21 @@
 # https://docs.bazel.build/versions/master/be/c-cpp.html#cc_library
 cc_library(
-    name = "SolutionLib",
-    srcs = glob(["**/*.cc"]),
-    hdrs = glob(["**/*.h"]),
+    name = "GameLib",
+    srcs = ["game.cc"],
+    hdrs = ["game.h"],
     visibility = ["//visibility:public"],
+    deps = [
+        ":SnakeLib",
+        "@ncurses//:main",
+    ],
+)
+
+cc_library(
+    name = "SnakeLib",
+    srcs = ["snake.cc"],
+    hdrs = ["snake.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@ncurses//:main",
+    ],
 )

--- a/src/main/BUILD
+++ b/src/main/BUILD
@@ -2,5 +2,8 @@
 cc_binary(
     name = "main",
     srcs = ["main.cc"],
-    deps = ["//src/lib:SolutionLib", "@ncurses//:main"],
+    deps = [
+        "//src/lib:GameLib",
+        "//src/lib:SnakeLib",
+    ],
 )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -2,6 +2,8 @@ cc_test(
     name = "tests",
     srcs = glob(["**/*.cc"]),
     deps = [
-        "//src/lib:SolutionLib", "@ncurses//:main"
+        "//src/lib:GameLib",
+        "//src/lib:SnakeLib",
+        "@googletest//:gtest_main",
     ],
 )

--- a/tests/solution_test.cc
+++ b/tests/solution_test.cc
@@ -1,7 +1,15 @@
-#include "gtest/gtest.h"
+#include <ncurses.h>
+
 #include <vector>
+
+#include "gtest/gtest.h"
+#include "src/lib/game.h"
 #include "src/lib/snake.h"
 
 TEST(MoveSnake, DirRight) {
-    EXPECT_EQ(1.0, 1.0); 
+  initscr();
+
+  // Game* g = new Game();
+  // Snake* _s = new Snake(0, 10);
+  EXPECT_EQ(1.0, 1.0);
 }


### PR DESCRIPTION
I was able to pass the link issue by specifying library dependencies more accurately. Looks like using ncurses causes this error:

Error opening terminal: unknown.

Sounds like it has a problem with opening the terminal. Not sure this can be fixed easily.

But in general, I think your test should be independent from Ncurses. Currently your game object depends on ncurses in its constructor. Perhaps you can try moving these dependencies outside of the constructors and only test functionalities that don't depend on Ncurses.